### PR TITLE
fix(ci): use PACKAGE_NAME from workflow in rename script

### DIFF
--- a/.github/scripts/rename-packages.sh
+++ b/.github/scripts/rename-packages.sh
@@ -37,8 +37,10 @@ if [ -z "$VERSION" ] || [ -z "$DISTRO" ] || [ -z "$COMPONENT" ]; then
     exit 1
 fi
 
-# Package name and architecture
-PACKAGE_NAME="halpi2-daemon"
+# Package name - use PACKAGE_NAME env var (from workflow) or read from debian/control
+if [ -z "${PACKAGE_NAME:-}" ]; then
+    PACKAGE_NAME=$(grep "^Source:" debian/control | cut -d: -f2 | tr -d ' ')
+fi
 ARCH="arm64"
 
 OLD_NAME="${PACKAGE_NAME}_${VERSION}_${ARCH}.deb"


### PR DESCRIPTION
Same fix as #46 - use env var or debian/control instead of hardcoded name.