### PR TITLE
fix(ci): add explicit apt-distro and apt-component

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
     with:
       package-name: halpid
       package-description: 'HALPI2 hardware daemon (Python implementation)'
+      apt-distro: any
       apt-component: hatlabs
       runs-on: ubuntu-latest-arm64
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ jobs:
   publish:
     uses: hatlabs/shared-workflows/.github/workflows/publish-stable.yml@main
     with:
+      apt-distro: any
       apt-component: hatlabs
     secrets:
       APT_REPO_PAT: ${{ secrets.APT_REPO_PAT }}


### PR DESCRIPTION
## Summary
- Add explicit `apt-distro: any` and `apt-component: hatlabs` to both main.yml and release.yml
- Prepares for making these inputs required in shared-workflows

## Context
Part of a multi-repo update to make apt-distro and apt-component required inputs in shared-workflows, preventing silent fallback to defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)